### PR TITLE
Improve Gradle setup

### DIFF
--- a/mountiplex-gradle-plugin/src/main/java/com/bergerkiller/mountiplex/gradle/GenerateTemplateHandles.java
+++ b/mountiplex-gradle-plugin/src/main/java/com/bergerkiller/mountiplex/gradle/GenerateTemplateHandles.java
@@ -19,7 +19,7 @@ import java.util.Map;
 /**
  * Parses template text files and generates the reflection Handle classes
  */
-public abstract class GenerateReflection extends DefaultTask {
+public abstract class GenerateTemplateHandles extends DefaultTask {
     private static void registerGenerators(Map<TypeDeclaration, TemplateGenerator> pool, ClassDeclaration cDec, TemplateGenerator gen) {
         pool.put(cDec.type, gen);
         for (ClassDeclaration subCDec : cDec.subclasses) {

--- a/mountiplex-gradle-plugin/src/main/java/com/bergerkiller/mountiplex/gradle/MountiplexExtension.java
+++ b/mountiplex-gradle-plugin/src/main/java/com/bergerkiller/mountiplex/gradle/MountiplexExtension.java
@@ -1,31 +1,43 @@
 package com.bergerkiller.mountiplex.gradle;
 
-import org.gradle.api.provider.MapProperty;
-import org.gradle.api.provider.Property;
+import org.gradle.api.Project;
+import org.gradle.api.plugins.JavaPlugin;
+import org.gradle.api.tasks.SourceSetContainer;
+import org.gradle.api.tasks.TaskProvider;
+import org.gradle.api.tasks.compile.JavaCompile;
 
-/**
- * Extends the properties of {@link GenerateReflection}
- */
+import javax.inject.Inject;
+import java.io.File;
+
 public abstract class MountiplexExtension {
+    @Inject
+    public abstract Project getProject();
 
-    /**
-     * The source template .txt file. This is the first source .txt file read.
-     *
-     * @return source template .txt file
-     */
-    public abstract Property<String> getSource();
+    public void generateTemplateHandles() {
+        getProject().getPlugins().withType(JavaPlugin.class, javaPlugin -> {
+            SourceSetContainer sourceSets = getProject().getExtensions().getByType(SourceSetContainer.class);
+            sourceSets.configureEach(sourceSet -> {
+                sourceSet.java(java -> {
+                    java.srcDir(getProject().getTasks().named("generateTemplateHandles"));
+                });
+            });
+        });
+    }
 
-    /**
-     * The package root where generated Handle classes are placed
-     *
-     * @return target package
-     */
-    public abstract Property<String> getGenerated();
+    public void remapAnnotationStrings() {
+        getProject().getPlugins().withType(JavaPlugin.class, javaPlugin -> {
+            SourceSetContainer sourceSets = getProject().getExtensions().getByType(SourceSetContainer.class);
+            sourceSets.configureEach(sourceSet -> {
+                TaskProvider<JavaCompile> compile = getProject().getTasks().named(sourceSet.getCompileJavaTaskName(), JavaCompile.class);
+                TaskProvider<RemapAnnotationStrings> remapAnnotations = getProject().getTasks().named(RemapAnnotationStrings.getTaskName(sourceSet), RemapAnnotationStrings.class);
 
-    /**
-     * Variables used while parsing the template files. Optional.
-     *
-     * @return variables
-     */
-    public abstract MapProperty<String, String> getVariables();
+                compile.configure(task -> {
+                    task.getDestinationDirectory().set(new File(getProject().getBuildDir(), "mountiplex-classes/" + sourceSet.getName()));
+                });
+
+                sourceSet.compiledBy(remapAnnotations);
+                sourceSet.getJava().compiledBy(remapAnnotations, RemapAnnotationStrings::getOutputDirectory);
+            });
+        });
+    }
 }

--- a/mountiplex-gradle-plugin/src/main/java/com/bergerkiller/mountiplex/gradle/MountiplexExtension.java
+++ b/mountiplex-gradle-plugin/src/main/java/com/bergerkiller/mountiplex/gradle/MountiplexExtension.java
@@ -9,10 +9,21 @@ import org.gradle.api.tasks.compile.JavaCompile;
 import javax.inject.Inject;
 import java.io.File;
 
+/**
+ * Utility methods to set up the plumbing for Mountiplex tasks.
+ */
 public abstract class MountiplexExtension {
+    /**
+     * Returns the project this extension was applied to.
+     *
+     * @return The project.
+     */
     @Inject
-    public abstract Project getProject();
+    protected abstract Project getProject();
 
+    /**
+     * Adds the generateTemplateHandles task to all source sets.
+     */
     public void generateTemplateHandles() {
         getProject().getPlugins().withType(JavaPlugin.class, javaPlugin -> {
             SourceSetContainer sourceSets = getProject().getExtensions().getByType(SourceSetContainer.class);
@@ -24,6 +35,11 @@ public abstract class MountiplexExtension {
         });
     }
 
+    /**
+     * Configures annotation string remapping for all source sets.
+     *
+     * @see RemapAnnotationStrings
+     */
     public void remapAnnotationStrings() {
         getProject().getPlugins().withType(JavaPlugin.class, javaPlugin -> {
             SourceSetContainer sourceSets = getProject().getExtensions().getByType(SourceSetContainer.class);

--- a/mountiplex-gradle-plugin/src/main/java/com/bergerkiller/mountiplex/gradle/MountiplexPlugin.java
+++ b/mountiplex-gradle-plugin/src/main/java/com/bergerkiller/mountiplex/gradle/MountiplexPlugin.java
@@ -8,43 +8,28 @@ import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.compile.AbstractCompile;
 import org.gradle.api.tasks.compile.JavaCompile;
 
-import java.io.File;
-
 /**
  * Main Mountiplex Gradle plugin instance which defines the tasks that can be done
  */
 public class MountiplexPlugin implements Plugin<Project> {
     @Override
     public void apply(Project project) {
-        MountiplexExtension extension = project.getExtensions().create("mountiplex", MountiplexExtension.class);
+        project.getExtensions().create("mountiplex", MountiplexExtension.class);
 
-        TaskProvider<GenerateReflection> generateReflection = project.getTasks().register("generateReflection", GenerateReflection.class, task -> {
+        TaskProvider<GenerateTemplateHandles> generateTemplateHandles = project.getTasks().register("generateTemplateHandles", GenerateTemplateHandles.class, task -> {
             task.getSourceDirectory().set(project.file("src/main/templates"));
             task.getOutputDirectory().set(project.file("src/main/generated"));
-            task.getSource().set(extension.getSource());
-            task.getTarget().set(extension.getGenerated());
-            task.getVariables().set(extension.getVariables());
         });
 
         project.getPlugins().withType(JavaPlugin.class, javaPlugin -> {
             SourceSetContainer sourceSets = project.getExtensions().getByType(SourceSetContainer.class);
             sourceSets.configureEach(sourceSet -> {
-                sourceSet.getJava().srcDir(generateReflection);
-
                 TaskProvider<JavaCompile> compile = project.getTasks().named(sourceSet.getCompileJavaTaskName(), JavaCompile.class);
-
-                TaskProvider<RemapAnnotations> remapAnnotations = project.getTasks().register(sourceSet.getTaskName("remap", "annotations"), RemapAnnotations.class, task -> {
+                project.getTasks().register(RemapAnnotationStrings.getTaskName(sourceSet), RemapAnnotationStrings.class, task -> {
                     task.dependsOn(compile);
                     task.getSourceDirectory().from(sourceSet.getJava().getSourceDirectories());
                     task.getInputDirectory().set(compile.flatMap(AbstractCompile::getDestinationDirectory));
                 });
-
-                compile.configure(task -> {
-                    task.getDestinationDirectory().set(new File(project.getBuildDir(), "mountiplex-classes/" + sourceSet.getName()));
-                });
-
-                sourceSet.compiledBy(remapAnnotations);
-                sourceSet.getJava().compiledBy(remapAnnotations, RemapAnnotations::getOutputDirectory);
             });
         });
     }

--- a/mountiplex-gradle-plugin/src/main/java/com/bergerkiller/mountiplex/gradle/RemapAnnotationStrings.java
+++ b/mountiplex-gradle-plugin/src/main/java/com/bergerkiller/mountiplex/gradle/RemapAnnotationStrings.java
@@ -5,22 +5,36 @@ import com.bergerkiller.mountiplex.reflection.util.asm.SourceFileProcessor;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.DirectoryProperty;
-import org.gradle.api.tasks.*;
+import org.gradle.api.tasks.InputDirectory;
+import org.gradle.api.tasks.InputFiles;
+import org.gradle.api.tasks.OutputDirectory;
+import org.gradle.api.tasks.PathSensitive;
+import org.gradle.api.tasks.PathSensitivity;
+import org.gradle.api.tasks.SourceSet;
+import org.gradle.api.tasks.TaskAction;
 import org.gradle.work.ChangeType;
 import org.gradle.work.FileChange;
 import org.gradle.work.Incremental;
 import org.gradle.work.InputChanges;
 
 import java.io.File;
-import java.util.*;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * Parses source files and places block-comment strings inside variables inside
  * annotations denoted with the same variable name. This is mainly to add multi-string
  * syntax to Java 8.
  */
-public abstract class RemapAnnotations extends DefaultTask {
+public abstract class RemapAnnotationStrings extends DefaultTask {
     private final SourceFileProcessor sourceFileProcessor = new SourceFileProcessor();
+
+    static String getTaskName(SourceSet sourceSet) {
+        return sourceSet.getTaskName("remap", "annotations");
+    }
 
     private static String getClassName(String classFileName) {
         if (!classFileName.endsWith(".class")) {


### PR DESCRIPTION
Renamed `generateReflection` to `generateTemplateHandles`.
Tasks are always created (like before), the functions in the `mountiplex` extension setup the plumbing to actually make them run.
For example, `generateTemplateHandles()` adds the `generateTemplateHandles` task as a source directory to all source sets.
```kts
mountiplex {
    generateTemplateHandles()
    remapAnnotationStrings()
}

tasks {
    generateTemplateHandles {
        source.set("com/bergerkiller/templates/init.txt")
        target.set("com/bergerkiller/generated")
        variables.put("version", "1.19.3")
    }
}
```